### PR TITLE
Changed AS400Text constructor in order to remove encoding parameter

### DIFF
--- a/java/src/nodejt400/Pgm.java
+++ b/java/src/nodejt400/Pgm.java
@@ -207,7 +207,7 @@ class TextPgmParam extends PgmParam
   public TextPgmParam(String name, Props paramDef)
   {
     super(name, paramDef);
-    parser = new AS400Text(paramDef.getFirstInt("size", "precision"), "Cp871");
+    parser = new AS400Text(paramDef.getFirstInt("size", "precision"));
   }
 
   @Override


### PR DESCRIPTION
When you create a program with a parameters that matches AS400Text type, this object was created with a constructor that need the encoding as parameter; which was hardcoded as Cp871 (IBM Iceland) [https://www.ibm.com/support/knowledgecenter/en/SSZHFX_9.2.0/progref/topics/encode.html](url). So if the as400 server uses another encoding you get wrong results as it will translate input/output characters in a wrong way.

Now I changed the constructor to the one that need only the precision parameter, so that jt400 will try to use a CCSID based on the default locale. In this way translations should work in every situation. [https://sourceforge.net/p/jt400/svn/3937/tree/trunk/src/com/ibm/as400/access/AS400Text.java#l39](url)