### PR TITLE
fix(stream): release the JDBC result stream when it is destroyed

### DIFF
--- a/ts-src/lib/baseConnection.ts
+++ b/ts-src/lib/baseConnection.ts
@@ -65,6 +65,7 @@ export const createBaseConnection = function (
         jdbcStreamPromise: jdbcConnection
           .queryAsStream(sql, jsonParams, 100)
           .catch(handleError({ sql, params })),
+        logger,
       })
       stream.on('end', () => {
         logger.info(
@@ -122,6 +123,7 @@ export const createBaseConnection = function (
               options = options || {}
               stream = new JdbcStream({
                 jdbcStream: statement.asStreamSync(options.bufferSize || 100),
+                logger,
               })
               stream.on('end', () => {
                 logger.info(
@@ -150,6 +152,7 @@ export const createBaseConnection = function (
                     jdbcStream: statement.asStreamSync(
                       options.bufferSize || 100,
                     ),
+                    logger,
                   })
                   stream.on('end', () => {
                     logger.info(

--- a/ts-src/lib/connection.ts
+++ b/ts-src/lib/connection.ts
@@ -72,6 +72,7 @@ export function createConnection({
           opt.schema,
           opt.table || '%',
         ),
+        logger,
       }).pipe(JSONStream.parse([true]))
     },
     getColumns(opt) {

--- a/ts-src/lib/jdbcstream.ts
+++ b/ts-src/lib/jdbcstream.ts
@@ -1,29 +1,56 @@
 import { inherits } from 'util'
 import { Readable } from 'stream'
+import { createDefaultLogger } from './logger.js'
 
 export function JdbcStream(opt) {
   Readable.call(this, { objectMode: false })
   this._jdbcStream = opt.jdbcStream
   this._jdbcStreamPromise = opt.jdbcStreamPromise
+  this._logger = opt.logger || createDefaultLogger()
+  // Tracks whether the Java-side stream still owns a connection. It is set as
+  // soon as a close is initiated, and also when the Java side closes itself
+  // (end of data, or a read error it handles internally), so _destroy never
+  // returns the same connection to the pool a second time.
+  this._jdbcStreamClosed = false
+  if (this._jdbcStreamPromise) {
+    // Park a permanent no-op handler on the promise. _read attaches the real
+    // handler, but only once a consumer actually reads. A stream that is
+    // created and then never read would otherwise leave the rejection
+    // unhandled, which terminates the process under Node's default policy.
+    this._jdbcStreamPromise.catch(() => undefined)
+  }
 }
 
 inherits(JdbcStream, Readable)
 
+function closeJdbcStream(context, jdbcStream) {
+  context._jdbcStreamClosed = true
+  return jdbcStream.close().catch((err) => {
+    // Failing to close is not fatal for the consumer: every row has already
+    // been delivered. Report it through the logger rather than emitting
+    // 'error', which crashes consumers that have no error listener attached.
+    context._logger.error({ err }, 'IBMI DB result stream close failed')
+  })
+}
+
 function read(context) {
   if (context._closed) {
-    context._jdbcStream.close().catch((err) => {
-      if (err) {
-        context.emit('error', err)
-      }
-    })
+    closeJdbcStream(context, context._jdbcStream)
     context.push(null)
   } else {
     context._jdbcStream
       .read()
       .then((res) => {
+        if (res === null) {
+          // End of data: the Java stream has already closed itself and
+          // returned its connection, so _destroy must not close it again.
+          context._jdbcStreamClosed = true
+        }
         context.push(res)
       })
       .catch((err) => {
+        // The Java stream closes itself before propagating a read failure.
+        context._jdbcStreamClosed = true
         context.emit('error', err)
       })
   }
@@ -31,6 +58,32 @@ function read(context) {
 
 JdbcStream.prototype.close = function () {
   this._closed = true
+}
+
+/**
+ * Release the Java-side result stream when this stream is destroyed -- either
+ * by a consumer aborting early, or by an error raised further down a pipe()
+ * chain. Without this the result set and its pooled connection are never
+ * released, because the ordinary close path only runs on the next _read,
+ * which in that situation never comes.
+ */
+JdbcStream.prototype._destroy = function (err, cb) {
+  if (this._jdbcStreamClosed) {
+    cb(err)
+  } else if (this._jdbcStream) {
+    closeJdbcStream(this, this._jdbcStream).then(() => cb(err))
+  } else if (this._jdbcStreamPromise) {
+    // Destroyed before the Java stream was ever handed over: close it as soon
+    // as it materialises, otherwise it leaks a pooled connection.
+    this._jdbcStreamPromise
+      .then((jdbcStream) =>
+        jdbcStream ? closeJdbcStream(this, jdbcStream) : undefined,
+      )
+      .catch(() => undefined)
+    cb(err)
+  } else {
+    cb(err)
+  }
 }
 
 JdbcStream.prototype._read = function () {

--- a/ts-src/unit-test/jdbcstream-spec.ts
+++ b/ts-src/unit-test/jdbcstream-spec.ts
@@ -1,0 +1,175 @@
+import assert from 'assert'
+import { JdbcStream } from '../lib/jdbcstream.js'
+import { Logger } from '../lib/logger.js'
+
+/**
+ * Stand-in for the Java ResultStream. It records how often close() was
+ * called, which is what the connection-lifecycle assertions below are
+ * really about: the Java close() returns the connection to the pool, so
+ * closing twice hands the same connection out twice, and never closing
+ * leaks it.
+ */
+function fakeJdbcStream(chunks: string[], closeError?: Error) {
+  let index = 0
+  return {
+    closeCount: 0,
+    readCount: 0,
+    read() {
+      this.readCount++
+      if (index < chunks.length) {
+        return Promise.resolve(chunks[index++])
+      }
+      // End of data. The real Java stream closes itself here.
+      this.closeCount++
+      return Promise.resolve(null)
+    },
+    close() {
+      this.closeCount++
+      return closeError ? Promise.reject(closeError) : Promise.resolve()
+    },
+  }
+}
+
+function collectingLogger(): Logger & { errors: any[] } {
+  const errors: any[] = []
+  return {
+    errors,
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (...args: any[]) => {
+      errors.push(args)
+    },
+  }
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 10))
+
+describe('JdbcStream', () => {
+  it('should read every chunk and end', (done) => {
+    const jdbcStream = fakeJdbcStream(['[[1]]', '[[2]]'])
+    const stream = new JdbcStream({ jdbcStream }) as any
+    const received: string[] = []
+
+    stream.on('data', (chunk) => received.push(chunk.toString()))
+    stream.on('end', () => {
+      assert.deepStrictEqual(received, ['[[1]]', '[[2]]'])
+      done()
+    })
+  })
+
+  it('should not close the java stream again after it ended by itself', async () => {
+    const jdbcStream = fakeJdbcStream(['[[1]]'])
+    const stream = new JdbcStream({ jdbcStream }) as any
+
+    await new Promise((resolve) => {
+      stream.on('data', () => {})
+      stream.on('end', resolve)
+    })
+    await tick()
+
+    // Exactly one close: the one the Java stream performs at end of data.
+    // A second one would return the same connection to the pool twice.
+    assert.strictEqual(jdbcStream.closeCount, 1)
+  })
+
+  it('should close the java stream when a consumer destroys it early', async () => {
+    const jdbcStream = fakeJdbcStream(['[[1]]', '[[2]]', '[[3]]'])
+    const stream = new JdbcStream({ jdbcStream }) as any
+
+    await new Promise((resolve) => stream.once('data', resolve))
+    assert.strictEqual(jdbcStream.closeCount, 0)
+
+    stream.destroy()
+    await tick()
+
+    assert.strictEqual(jdbcStream.closeCount, 1)
+  })
+
+  it('should close the java stream when destroyed with an error', async () => {
+    const jdbcStream = fakeJdbcStream(['[[1]]', '[[2]]'])
+    const stream = new JdbcStream({ jdbcStream }) as any
+    const failure = new Error('downstream blew up')
+    let emitted: Error | undefined
+
+    stream.on('error', (err) => {
+      emitted = err
+    })
+    await new Promise((resolve) => stream.once('data', resolve))
+    stream.destroy(failure)
+    await tick()
+
+    assert.strictEqual(jdbcStream.closeCount, 1)
+    assert.strictEqual(emitted, failure)
+  })
+
+  it('should close the java stream when destroyed before the promise resolved', async () => {
+    const jdbcStream = fakeJdbcStream(['[[1]]'])
+    const stream = new JdbcStream({
+      jdbcStreamPromise: Promise.resolve(jdbcStream),
+    }) as any
+
+    stream.destroy()
+    await tick()
+
+    assert.strictEqual(jdbcStream.closeCount, 1)
+    assert.strictEqual(jdbcStream.readCount, 0)
+  })
+
+  it('should log rather than emit an error when close fails', async () => {
+    const jdbcStream = fakeJdbcStream(['[[1]]'], new Error('close failed'))
+    const logger = collectingLogger()
+    const stream = new JdbcStream({ jdbcStream, logger }) as any
+    let emitted: Error | undefined
+
+    // No 'error' listener beyond this assertion helper: emitting here is
+    // exactly what used to crash consumers that had already received all
+    // of their rows.
+    stream.on('error', (err) => {
+      emitted = err
+    })
+    await new Promise((resolve) => stream.once('data', resolve))
+    stream.destroy()
+    await tick()
+
+    assert.strictEqual(emitted, undefined)
+    assert.strictEqual(logger.errors.length, 1)
+    assert.strictEqual(
+      logger.errors[0][1],
+      'IBMI DB result stream close failed',
+    )
+  })
+
+  it('should not leave an unhandled rejection when the stream is never read', async () => {
+    const unhandled: any[] = []
+    const onUnhandled = (reason) => unhandled.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      // Created and then abandoned, which is what happens when the caller
+      // never consumes the stream returned by createReadStream.
+      const abandoned = new JdbcStream({
+        jdbcStreamPromise: Promise.reject(new Error('connection refused')),
+      })
+      assert.ok(abandoned)
+      await tick()
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled)
+    }
+
+    assert.deepStrictEqual(unhandled, [])
+  })
+
+  it('should still emit the rejection to a reading consumer', (done) => {
+    const failure = new Error('connection refused')
+    const stream = new JdbcStream({
+      jdbcStreamPromise: Promise.reject(failure),
+    }) as any
+
+    stream.on('error', (err) => {
+      assert.strictEqual(err, failure)
+      done()
+    })
+    stream.resume()
+  })
+})


### PR DESCRIPTION
# Release the JDBC result stream when it is destroyed

Branch: `fix/jdbc-result-stream-lifecycle`

Three independent problems in `ts-src/lib/jdbcstream.ts`. They are grouped
because they are all about what happens to a result stream that does not end
the way the happy path assumes, and they overlap in the same twenty lines.

## 1. A destroyed stream leaks its connection

`JdbcStream` only closes the Java-side `ResultStream` from inside `_read`, on
the tick after `close()` has set the `_closed` flag. A consumer that stops
early never gets there, because no further `_read` arrives.

```js
for await (const row of stream) {
  if (row.ID === wanted) break // connection never comes back
}
```

The same happens on `stream.destroy()` and when a later stage of a `pipe()`
chain errors. `ResultStream.close()` is what returns the connection to the
pool, so each occurrence permanently removes one connection. With
`AS400JDBCConnectionPool` there is nothing that reclaims it afterwards, and
once the pool is drained unrelated queries start blocking.

Fixed by implementing `_destroy`, which also covers being destroyed before
the `queryAsStream` promise has resolved.

### Why the extra flag

`ResultStream.close()` returns its connection unconditionally, and
`ResultStream.read()` already calls `close()` at end of data. So a naive
`_destroy` would close a second time on the normal path — Node calls
`_destroy` after `'end'` because `autoDestroy` defaults to true — and hand the
same connection to two callers.

A `_jdbcStreamClosed` flag now tracks whether the Java side still owns the
connection, and `_destroy` does nothing once it does not.

**Follow-up worth considering:** making `ResultStream.close()` idempotent on
the Java side would make this unnecessary and would also protect the one case
this patch deliberately leaves alone — a failure inside `read()`'s `init`
block, where the Java code has *not* closed but this patch assumes it has,
because double-returning a connection is worse than the leak that already
exists there today. Happy to send that as a separate PR; it needs a jar
rebuild, so it did not belong in this one.

## 2. An abandoned stream can terminate the process

`_jdbcStreamPromise` gets its rejection handler in `_read`. A stream that is
created and never read — the normal outcome when the query itself fails and
the caller never subscribes — leaves the rejection unhandled. On every Node
version this package supports (`engines: >=16`), the default policy for that
is to terminate the process.

The constructor now parks a no-op handler on the promise. The real handler in
`_read` is unchanged, so a consumer that does read still gets the error.

## 3. A close failure crashes consumers that already got their rows

A failing `close()` was reported with `emit('error')`. At that point every row
has been delivered and `'end'` may already have fired, so consumers have
typically stopped listening for errors — and an `'error'` with no listener is
an uncaught exception. A connection that could not be released turned into a
process-level failure.

It now goes to the `Logger` the library already has. `baseConnection` and
`connection` pass their logger in at the three construction sites; the default
stays the existing no-op logger, so nothing is printed unless a logger is
configured.

## Tests

`ts-src/unit-test/jdbcstream-spec.ts`, 8 cases, using a fake Java stream that
counts `close()` calls. No JVM and no IBM i, so they run in CI.

Against the current implementation, **5 of the 8 fail**:

```
✔ should read every chunk and end
✔ should not close the java stream again after it ended by itself
1) should close the java stream when a consumer destroys it early
2) should close the java stream when destroyed with an error
3) should close the java stream when destroyed before the promise resolved
4) should log rather than emit an error when close fails
5) should not leave an unhandled rejection when the stream is never read
✔ should still emit the rejection to a reading consumer
```

The three that already pass are there on purpose: they guard the behaviour
this change could plausibly break, in particular the double-close.

## Verification

```
npm run build && npm test       -> 40 passing
npm run test-cjs                -> 40 passing
npm run lint                    -> clean
npm run format-verify           -> clean
```

No Java change, no jar rebuild, no new dependency, no public API change.
