### PR TITLE
feat(error): expose Java SQLException diagnostics on Oops context

### DIFF
--- a/ts-src/lib/handleError.ts
+++ b/ts-src/lib/handleError.ts
@@ -1,5 +1,94 @@
 import { Oops } from 'oops-error'
 
+/** Guards against a chain of SQLExceptions that loops back on itself. */
+const MAX_CHAINED_EXCEPTIONS = 5
+
+/**
+ * Calls a no-argument Java accessor over the JNI bridge, if it exists.
+ *
+ * Diagnostics are best effort: an error may be a plain JavaScript Error, a
+ * java.sql.SQLException, or any other Throwable, and the bridge itself can
+ * throw while crossing. Nothing here may turn a database error into a
+ * different, more confusing one.
+ */
+function safeSyncCall(obj: any, method: string): any {
+  try {
+    if (obj && typeof obj[method] === 'function') {
+      return obj[method]()
+    }
+  } catch {
+    // Ignored on purpose, see above.
+  }
+  return undefined
+}
+
+/**
+ * Extracts the parts of a Java exception that identify a database error --
+ * SQLSTATE, vendor error code and the exception class -- along with any
+ * exceptions chained behind it. DB2 for i regularly puts the detail that
+ * actually explains a failure in those chained exceptions rather than in the
+ * first message.
+ *
+ * Returns undefined when there is nothing Java-shaped to report.
+ */
+function extractJavaCauseInfo(cause: any): any {
+  if (!cause) {
+    return undefined
+  }
+  const message = safeSyncCall(cause, 'getMessageSync')
+  const sqlState = safeSyncCall(cause, 'getSQLStateSync')
+  const errorCode = safeSyncCall(cause, 'getErrorCodeSync')
+
+  let javaClass: string | undefined
+  const cls = safeSyncCall(cause, 'getClassSync')
+  if (cls) {
+    const name = safeSyncCall(cls, 'getNameSync')
+    if (typeof name === 'string') {
+      javaClass = name
+    }
+  }
+
+  const chained: any[] = []
+  let next = safeSyncCall(cause, 'getNextExceptionSync')
+  while (next && chained.length < MAX_CHAINED_EXCEPTIONS) {
+    const link: any = {}
+    const linkMessage = safeSyncCall(next, 'getMessageSync')
+    const linkSqlState = safeSyncCall(next, 'getSQLStateSync')
+    const linkErrorCode = safeSyncCall(next, 'getErrorCodeSync')
+    if (linkMessage !== undefined) {
+      link.message = linkMessage
+    }
+    if (linkSqlState !== undefined) {
+      link.sqlState = linkSqlState
+    }
+    if (linkErrorCode !== undefined) {
+      link.errorCode = linkErrorCode
+    }
+    if (Object.keys(link).length > 0) {
+      chained.push(link)
+    }
+    next = safeSyncCall(next, 'getNextExceptionSync')
+  }
+
+  const info: any = {}
+  if (message !== undefined) {
+    info.message = message
+  }
+  if (sqlState !== undefined) {
+    info.sqlState = sqlState
+  }
+  if (errorCode !== undefined) {
+    info.errorCode = errorCode
+  }
+  if (javaClass !== undefined) {
+    info.javaClass = javaClass
+  }
+  if (chained.length > 0) {
+    info.chained = chained
+  }
+  return Object.keys(info).length > 0 ? info : undefined
+}
+
 export function handleError(context: { [key: string]: any }) {
   return (err: any) => {
     const errMsg =
@@ -14,9 +103,12 @@ export function handleError(context: { [key: string]: any }) {
       errMsg.includes('java.net.UnknownHostException')
         ? 'OperationalError'
         : 'ProgrammerError'
+    // The Java exception is either wrapped by the bridge or is the error
+    // itself, matching how errMsg is resolved above.
+    const cause = extractJavaCauseInfo(err.cause) || extractJavaCauseInfo(err)
     throw new Oops({
       message,
-      context,
+      context: cause ? { ...context, cause } : context,
       category,
       cause: err,
     })

--- a/ts-src/unit-test/handleError-spec.ts
+++ b/ts-src/unit-test/handleError-spec.ts
@@ -1,0 +1,162 @@
+import assert from 'assert'
+import { handleError } from '../lib/handleError.js'
+
+/**
+ * Stand-in for a java.sql.SQLException as it arrives over the JNI bridge:
+ * a JavaScript object carrying the synchronous accessors of the Java
+ * object. No JVM is involved, so these run anywhere.
+ */
+function javaSqlException(opt: {
+  message?: string
+  sqlState?: string
+  errorCode?: number
+  className?: string
+  next?: any
+}) {
+  return {
+    getMessageSync: () => opt.message,
+    getSQLStateSync: () => opt.sqlState,
+    getErrorCodeSync: () => opt.errorCode,
+    getClassSync: () =>
+      opt.className ? { getNameSync: () => opt.className } : undefined,
+    getNextExceptionSync: () => opt.next,
+  }
+}
+
+function captureOops(err: any, context: any = { sql: 'select 1 from x' }) {
+  try {
+    handleError(context)(err)
+  } catch (oops) {
+    return oops as any
+  }
+  throw new Error('handleError did not throw')
+}
+
+describe('handleError', () => {
+  it('should keep message and category for a plain error', () => {
+    const oops = captureOops(new Error('something went wrong'))
+
+    assert.strictEqual(oops.message, 'something went wrong')
+    assert.strictEqual(oops.category, 'ProgrammerError')
+  })
+
+  it('should keep slicing the message of a wrapped java exception', () => {
+    const oops = captureOops({
+      cause: javaSqlException({
+        message: 'java.sql.SQLException: Column not found: NOPE\n\tat com.ibm',
+      }),
+    })
+
+    assert.strictEqual(oops.message, 'Column not found: NOPE')
+    assert.strictEqual(oops.category, 'ProgrammerError')
+  })
+
+  it('should keep categorising connection failures as operational', () => {
+    const oops = captureOops({
+      cause: javaSqlException({
+        message: 'java.sql.SQLException: The connection does not exist.\n\tat',
+      }),
+    })
+
+    assert.strictEqual(oops.category, 'OperationalError')
+  })
+
+  it('should keep categorising unknown hosts as operational', () => {
+    const oops = captureOops(
+      new Error('boom: java.net.UnknownHostException\nat somewhere'),
+    )
+
+    assert.strictEqual(oops.category, 'OperationalError')
+  })
+
+  it('should add sqlState, errorCode and class to the context', () => {
+    const oops = captureOops({
+      cause: javaSqlException({
+        message: 'java.sql.SQLException: Column not found: NOPE\n\tat com.ibm',
+        sqlState: '42703',
+        errorCode: -206,
+        className: 'com.ibm.as400.access.AS400JDBCSQLSyntaxErrorException',
+      }),
+    })
+
+    assert.deepStrictEqual(oops.context.cause, {
+      message: 'java.sql.SQLException: Column not found: NOPE\n\tat com.ibm',
+      sqlState: '42703',
+      errorCode: -206,
+      javaClass: 'com.ibm.as400.access.AS400JDBCSQLSyntaxErrorException',
+    })
+    // The caller's own context is preserved alongside it.
+    assert.strictEqual(oops.context.sql, 'select 1 from x')
+  })
+
+  it('should collect chained exceptions', () => {
+    const oops = captureOops({
+      cause: javaSqlException({
+        message: 'first\nline',
+        sqlState: '23505',
+        next: javaSqlException({
+          message: 'second',
+          sqlState: '42703',
+          errorCode: -206,
+          next: javaSqlException({ message: 'third', sqlState: '22001' }),
+        }),
+      }),
+    })
+
+    assert.deepStrictEqual(oops.context.cause.chained, [
+      { message: 'second', sqlState: '42703', errorCode: -206 },
+      { message: 'third', sqlState: '22001' },
+    ])
+  })
+
+  it('should not loop forever on a self-referential chain', () => {
+    const looping: any = javaSqlException({ message: 'loop', sqlState: '5800' })
+    looping.getNextExceptionSync = () => looping
+
+    const oops = captureOops({ cause: looping })
+
+    assert.strictEqual(oops.context.cause.chained.length, 5)
+  })
+
+  it('should read diagnostics when the error itself is the java exception', () => {
+    const oops = captureOops(
+      javaSqlException({
+        message: 'java.sql.SQLException: Row not found\n\tat com.ibm',
+        sqlState: '02000',
+      }),
+    )
+
+    assert.strictEqual(oops.context.cause.sqlState, '02000')
+  })
+
+  it('should leave the context untouched when there is nothing java-shaped', () => {
+    const oops = captureOops(new Error('plain failure'), { sql: 'select 1' })
+
+    assert.deepStrictEqual(oops.context, { sql: 'select 1' })
+  })
+
+  it('should not fail when the java accessors throw', () => {
+    const hostile = {
+      getMessageSync: () => 'java.sql.SQLException: broken\n\tat com.ibm',
+      getSQLStateSync: () => {
+        throw new Error('bridge failure')
+      },
+      getErrorCodeSync: () => {
+        throw new Error('bridge failure')
+      },
+      getClassSync: () => {
+        throw new Error('bridge failure')
+      },
+      getNextExceptionSync: () => {
+        throw new Error('bridge failure')
+      },
+    }
+
+    const oops = captureOops({ cause: hostile })
+
+    assert.strictEqual(oops.message, 'broken')
+    assert.deepStrictEqual(oops.context.cause, {
+      message: 'java.sql.SQLException: broken\n\tat com.ibm',
+    })
+  })
+})


### PR DESCRIPTION
# Expose Java SQLException diagnostics on the Oops context

Branch: `feat/oops-java-cause-diagnostics`

## The problem

When a query fails, the `Oops` that reaches the caller carries a message
sliced out of the Java stack trace and nothing else that identifies the error.
The SQLSTATE, the vendor error code and the exception class all exist on the
Java exception, and none of them cross into JavaScript.

So callers end up matching on the message:

```js
catch (err) {
  if (err.message.includes('Duplicate key')) { ... }
}
```

which breaks on a different DB2 release, a different language setting on the
server, or a message this wrapper happens to slice differently.

## The change

`handleError` additionally puts the structured form on `context.cause`:

```js
{
  message: 'java.sql.SQLException: Column not found: NOPE\n\tat com.ibm...',
  sqlState: '42703',
  errorCode: -206,
  javaClass: 'com.ibm.as400.access.AS400JDBCSQLSyntaxErrorException',
  chained: [{ message, sqlState, errorCode }, ...]
}
```

so the check above becomes `err.context.cause.sqlState === '23505'`.

`getNextException` is walked as well. DB2 for i routinely leaves the detail
that actually explains a failure in the chained exceptions rather than in the
first message. The walk is bounded at five links so a self-referential chain
cannot spin.

## Deliberately additive

- The message and category heuristics are **untouched** — same slicing, same
  `OperationalError` / `ProgrammerError` decision, including the
  `UnknownHostException` special case.
- The caller's own context keys are preserved; `cause` is added next to them.
- `cause` is only added when there is something Java-shaped to report, so a
  plain JavaScript error produces exactly the same `Oops` as before.
- Absent fields are omitted rather than set to `undefined`, which keeps the
  object clean when it is serialised into a log.

Extraction goes through a helper that swallows anything the JNI bridge throws.
These diagnostics are a convenience; turning a database error into a different,
more confusing one while collecting them would not be.

The Java exception is read from `err.cause` first and from `err` itself
otherwise, mirroring how the existing code already resolves `errMsg`.

## Tests

`ts-src/unit-test/handleError-spec.ts`, 10 cases. A Java exception is faked
with a plain object carrying the `*Sync` accessors, so no JVM and no IBM i are
needed and they run in CI.

The split matters:

```
✔ should keep message and category for a plain error
✔ should keep slicing the message of a wrapped java exception
✔ should keep categorising connection failures as operational
✔ should keep categorising unknown hosts as operational
✔ should leave the context untouched when there is nothing java-shaped
1) should add sqlState, errorCode and class to the context
2) should collect chained exceptions
3) should not loop forever on a self-referential chain
4) should read diagnostics when the error itself is the java exception
5) should not fail when the java accessors throw
```

That is the result against the **current** implementation. The five that pass
are the behaviour-preservation guards — they demonstrate the change is purely
additive. The five that fail are the new field.

## Verification

```
npm run build && npm test       -> 42 passing
npm run test-cjs                -> 42 passing
npm run lint                    -> clean
npm run format-verify           -> clean
```

One file plus its spec. No Java change, no jar rebuild, no new dependency —
`oops-error` is already a dependency.
